### PR TITLE
Customize header with dropdown menu

### DIFF
--- a/assets/js/dropdown.js
+++ b/assets/js/dropdown.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', function () {
+    var dropdownParents = document.querySelectorAll('#primary-menu li.menu-item-has-children');
+    dropdownParents.forEach(function (parent) {
+        parent.classList.add('dropdown');
+        var link = parent.querySelector('a');
+        if (link) {
+            link.classList.add('dropdown-toggle');
+            link.setAttribute('data-bs-toggle', 'dropdown');
+            link.setAttribute('aria-expanded', 'false');
+        }
+        var submenu = parent.querySelector('.sub-menu');
+        if (submenu) {
+            submenu.classList.add('dropdown-menu');
+        }
+    });
+});

--- a/header.php
+++ b/header.php
@@ -8,9 +8,9 @@
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
 
-<header class="site-header navbar navbar-expand-lg navbar-dark" style="background-color: var(--wp--preset--color--theme-5);">
-    <div class="container">
-        <a class="navbar-brand" href="<?php echo esc_url( home_url( '/' ) ); ?>">
+<header class="site-header navbar navbar-expand-lg" style="background-color: #102624;">
+    <div class="container d-flex align-items-center py-2">
+        <a class="navbar-brand me-4" href="<?php echo esc_url( home_url( '/' ) ); ?>">
             <?php if ( has_custom_logo() ) : ?>
                 <?php the_custom_logo(); ?>
             <?php else : ?>
@@ -37,7 +37,15 @@
                     'fallback_cb'    => false,
                 ) );
                 ?>
-                <a href="tel:260-710-9103" class="btn btn-primary mt-3 d-lg-none">260.710.9103</a>
+                <div class="social-icons mt-3">
+                    <a href="#" class="text-light me-3"><i class="fab fa-facebook-f"></i></a>
+                    <a href="#" class="text-light me-3"><i class="fab fa-twitter"></i></a>
+                    <a href="#" class="text-light"><i class="fab fa-instagram"></i></a>
+                </div>
+                <div class="business-info text-light mt-3">
+                    <div class="business-name fw-bold mb-1"><?php bloginfo( 'name' ); ?></div>
+                    <div class="header-phone"><i class="fas fa-phone"></i> <a href="tel:260-710-9103" class="text-light text-decoration-none">260.710.9103</a></div>
+                </div>
             </div>
         </div>
 
@@ -47,11 +55,21 @@
                 'theme_location' => 'main',
                 'menu_id'        => 'primary-menu',
                 'container'      => false,
-                'menu_class'     => 'navbar-nav me-auto mb-2 mb-lg-0',
+                'menu_class'     => 'navbar-nav ms-auto mb-2 mb-lg-0',
                 'fallback_cb'    => false,
             ) );
             ?>
-            <a href="tel:260-710-9103" class="btn btn-primary ms-lg-3">260.710.9103</a>
+            <div class="header-right d-flex align-items-center ms-3">
+                <div class="social-icons me-3">
+                    <a href="#" class="text-light me-2"><i class="fab fa-facebook-f"></i></a>
+                    <a href="#" class="text-light me-2"><i class="fab fa-twitter"></i></a>
+                    <a href="#" class="text-light"><i class="fab fa-instagram"></i></a>
+                </div>
+                <div class="business-info text-end text-light">
+                    <div class="business-name fw-bold"><?php bloginfo( 'name' ); ?></div>
+                    <div class="header-phone"><i class="fas fa-phone"></i> <a href="tel:260-710-9103" class="text-light text-decoration-none">260.710.9103</a></div>
+                </div>
+            </div>
         </div>
     </div>
 </header>

--- a/load.php
+++ b/load.php
@@ -89,6 +89,13 @@ if ( ! function_exists( 'bark_styles' ) ) :
                 );
 
                 wp_register_style(
+                        'font-awesome',
+                        'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css',
+                        array(),
+                        '6.4.0'
+                );
+
+                wp_register_style(
                         'bark-style',
                         get_template_directory_uri() . '/style.css',
                         array( 'bootstrap-css' ),
@@ -96,6 +103,7 @@ if ( ! function_exists( 'bark_styles' ) ) :
                 );
 
                 wp_enqueue_style( 'bootstrap-css' );
+                wp_enqueue_style( 'font-awesome' );
                 wp_enqueue_style( 'bark-style' );
 
                 wp_register_script(
@@ -106,7 +114,16 @@ if ( ! function_exists( 'bark_styles' ) ) :
                         true
                 );
 
+                wp_register_script(
+                        'bark-dropdown',
+                        get_template_directory_uri() . '/assets/js/dropdown.js',
+                        array( 'bootstrap-js' ),
+                        wp_get_theme()->get( 'Version' ),
+                        true
+                );
+
                 wp_enqueue_script( 'bootstrap-js' );
+                wp_enqueue_script( 'bark-dropdown' );
 
         }
 

--- a/style.css
+++ b/style.css
@@ -1,9 +1,52 @@
-        width: 46px;
-        height: auto;
+/* Theme custom styles */
+
+.site-header {
+    background-color: #102624;
 }
 
-/* Ensure the logo fits nicely inside the Bootstrap navbar */
+.site-header .container {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+
+/* Logo size */
 .navbar-brand img {
-        max-height: 60px;
-        width: auto;
-        height: auto;
+    max-height: 15px;
+    width: auto;
+    height: auto;
+}
+
+/* Navigation links */
+.navbar-nav .nav-link {
+    color: #f7f7f3;
+}
+.navbar-nav .nav-link:hover,
+.navbar-nav .nav-link:focus {
+    color: #f2a307;
+}
+
+/* Dropdown */
+.dropdown-menu {
+    background-color: #102624;
+    border: none;
+}
+.dropdown-menu .dropdown-item {
+    color: #f7f7f3;
+}
+.dropdown-menu .dropdown-item:hover,
+.dropdown-menu .dropdown-item:focus {
+    background-color: #f2a307;
+    color: #102624;
+}
+
+/* Social icons */
+.social-icons a {
+    color: #f7f7f3;
+}
+.social-icons a:hover {
+    color: #f2a307;
+}
+
+.header-phone i {
+    margin-right: 4px;
+}


### PR DESCRIPTION
## Summary
- simplify navbar style with slim header
- add dropdown.js to convert WP menu markup to Bootstrap dropdowns
- load Font Awesome and dropdown script
- tweak header markup for social icons, business name, and phone
- restyle theme

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683e750cda348326b953cc6f05e821b4