### PR TITLE
Fix header parse error

### DIFF
--- a/header.php
+++ b/header.php
@@ -11,7 +11,7 @@
 <header class="site-header navbar navbar-expand-lg" style="background-color: #102624;">
     <div class="container-fluid d-flex align-items-center justify-content-between py-2 px-3">
         <div class="d-flex align-items-center">
-            <a class="navbar-brand me-4" href="<?php echo esc_url( home_url( '/' ); ?>">
+            <a class="navbar-brand me-4" href="<?php echo esc_url( home_url( '/' ) ); ?>">
                 <img src="/wp-content/uploads/2025/05/logo.min_.png" alt="<?php bloginfo( 'name' ); ?>" class="img-fluid" width="100" height="100" />
             </a>
             <div class="business-info ms-4 text-light">


### PR DESCRIPTION
## Summary
- fix syntax error in `header.php` by closing `esc_url()` call properly

## Testing
- `php -l header.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683e7dd614048326913a1a9f3bff4fd0