### PR TITLE
Rename theme and add version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "cosmickmedia/bark",
+    "name": "cosmickmedia/pupworld",
     "type": "wordpress-theme",
     "homepage": "https://cosmickmedia.com",
     "authors": [{

--- a/front-page.php
+++ b/front-page.php
@@ -2,7 +2,7 @@
 /**
  * Custom front page rebuilt from static backup.
  *
- * @package Bark
+ * @package Pup World
  */
 
 get_header();

--- a/functions.php
+++ b/functions.php
@@ -1,7 +1,9 @@
 <?php
 defined( 'ABSPATH' ) || exit;
 
-class BARK_THEME {
+define( 'PUPWORLD_VERSION', '1.0.1' );
+
+class PUPWORLD_THEME {
 	function __construct() {
 		add_action( 'after_setup_theme', [ $this, 'after_setup_theme' ] );
 		add_action( 'init', [ $this, 'register_nav_menus' ] );
@@ -27,6 +29,6 @@ class BARK_THEME {
 	}
 }
 
-$BARK_THEME = new BARK_THEME();
+$PUPWORLD_THEME = new PUPWORLD_THEME();
 
 require_once ( dirname( __FILE__ ) . '/load.php' );

--- a/load.php
+++ b/load.php
@@ -1,20 +1,20 @@
 <?php
 /**
- * Bark functions and definitions
+ * Pup World functions and definitions
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *
- * @package Bark
- * @since Bark 1.0
+ * @package Pup World
+ * @since Pup World 1.0
  */
 
 declare( strict_types = 1 );
 
-if ( ! function_exists( 'bark_unregister_patterns' ) ) :
+if ( ! function_exists( 'pupworld_unregister_patterns' ) ) :
 	/**
 	 * Unregister Jetpack patterns and core patterns bundled in WordPress.
 	 */
-	function bark_unregister_patterns() {
+        function pupworld_unregister_patterns() {
 		$pattern_names = array(
 			// Jetpack form patterns.
 			'contact-form',
@@ -44,24 +44,24 @@ if ( ! function_exists( 'bark_unregister_patterns' ) ) :
 
 endif;
 
-if ( ! function_exists( 'bark_setup' ) ) :
+if ( ! function_exists( 'pupworld_setup' ) ) :
 	/**
 	 * Sets up theme defaults and registers support for various WordPress features.
 	 *
-	 * @since Bark 1.0
+ * @since Pup World 1.0
 	 *
 	 * @return void
 	 */
-	function bark_setup() {
+        function pupworld_setup() {
 
 		// Enqueue editor styles.
 		add_editor_style( 'style.css' );
 		// Unregister Jetpack form patterns and core patterns bundled in WordPress.
 		// Simple sites
-		bark_unregister_patterns();
+                pupworld_unregister_patterns();
 		add_filter( 'wp_loaded', function () {
 			// Atomic sites
-			bark_unregister_patterns();
+                        pupworld_unregister_patterns();
 		} );
 		// Remove theme support for the core and featured patterns coming from the Dotorg pattern directory.
 		remove_theme_support( 'core-block-patterns' );
@@ -69,17 +69,17 @@ if ( ! function_exists( 'bark_setup' ) ) :
 
 endif;
 
-add_action( 'after_setup_theme', 'bark_setup' );
+add_action( 'after_setup_theme', 'pupworld_setup' );
 
-if ( ! function_exists( 'bark_styles' ) ) :
+if ( ! function_exists( 'pupworld_styles' ) ) :
         /**
          * Enqueue Bootstrap and theme styles.
          *
-         * @since Bark 1.0
+ * @since Pup World 1.0
          *
          * @return void
          */
-        function bark_styles() {
+        function pupworld_styles() {
 
                 wp_register_style(
                         'bootstrap-css',
@@ -96,15 +96,15 @@ if ( ! function_exists( 'bark_styles' ) ) :
                 );
 
                 wp_register_style(
-                        'bark-style',
+                        'pupworld-style',
                         get_template_directory_uri() . '/style.css',
                         array( 'bootstrap-css' ),
-                        wp_get_theme()->get( 'Version' )
+                        PUPWORLD_VERSION
                 );
 
                 wp_enqueue_style( 'bootstrap-css' );
                 wp_enqueue_style( 'font-awesome' );
-                wp_enqueue_style( 'bark-style' );
+                wp_enqueue_style( 'pupworld-style' );
 
                 wp_register_script(
                         'bootstrap-js',
@@ -115,18 +115,18 @@ if ( ! function_exists( 'bark_styles' ) ) :
                 );
 
                 wp_register_script(
-                        'bark-dropdown',
+                        'pupworld-dropdown',
                         get_template_directory_uri() . '/assets/js/dropdown.js',
                         array( 'bootstrap-js' ),
-                        wp_get_theme()->get( 'Version' ),
+                        PUPWORLD_VERSION,
                         true
                 );
 
                 wp_enqueue_script( 'bootstrap-js' );
-                wp_enqueue_script( 'bark-dropdown' );
+                wp_enqueue_script( 'pupworld-dropdown' );
 
         }
 
 endif;
 
-add_action( 'wp_enqueue_scripts', 'bark_styles' );
+add_action( 'wp_enqueue_scripts', 'pupworld_styles' );

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Bark ===
+=== Pup World ===
 Contributors: Automattic, Cosmick Media
 Requires at least: 6.4
 Tested up to: 6.4
@@ -13,13 +13,13 @@ Now includes Bootstrap 5.3 for styling and components.
 
 == Changelog ==
 
-= 1.0.0 =
+= 1.0.1 =
 * Initial release
 
 == Copyright ==
 
-Bark WordPress Theme, (C) 2024 Automattic
-Bark is distributed under the terms of the GNU GPL.
+Pup World WordPress Theme, (C) 2024 Automattic
+Pup World is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/style.css
+++ b/style.css
@@ -1,3 +1,8 @@
+/*
+Theme Name: Pup World
+Version: 1.0.1
+*/
+
 /* Theme custom styles */
 
 .site-header {


### PR DESCRIPTION
## Summary
- rename theme to Pup World
- add a version header in `style.css`
- update theme documentation and composer package name
- define `PUPWORLD_VERSION` constant and use it when enqueueing assets
- rename related functions and handles to the new pupworld prefix

## Testing
- `composer validate --no-check-all --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e81c5dc10832684ca7492ffcb4c9d