### PR TITLE
Update fonts to Varela Round

### DIFF
--- a/load.php
+++ b/load.php
@@ -88,12 +88,19 @@ if ( ! function_exists( 'pupworld_styles' ) ) :
                         '5.3.2'
                 );
 
-                wp_register_style(
-                        'font-awesome',
-                        'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css',
-                        array(),
-                        '6.4.0'
-                );
+               wp_register_style(
+                       'font-awesome',
+                       'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css',
+                       array(),
+                       '6.4.0'
+               );
+
+               wp_register_style(
+                       'pupworld-google-fonts',
+                       'https://fonts.googleapis.com/css2?family=Varela+Round&display=swap',
+                       array(),
+                       null
+               );
 
                 wp_register_style(
                         'pupworld-style',
@@ -102,9 +109,10 @@ if ( ! function_exists( 'pupworld_styles' ) ) :
                         PUPWORLD_VERSION
                 );
 
-                wp_enqueue_style( 'bootstrap-css' );
-                wp_enqueue_style( 'font-awesome' );
-                wp_enqueue_style( 'pupworld-style' );
+               wp_enqueue_style( 'bootstrap-css' );
+               wp_enqueue_style( 'font-awesome' );
+               wp_enqueue_style( 'pupworld-google-fonts' );
+               wp_enqueue_style( 'pupworld-style' );
 
                 wp_register_script(
                         'bootstrap-js',

--- a/style.css
+++ b/style.css
@@ -5,6 +5,14 @@ Version: 1.0.1
 
 /* Theme custom styles */
 
+body {
+    font-family: Arial, sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Varela Round', sans-serif;
+}
+
 .site-header {
     background-color: #102624;
 }

--- a/styles/banjo.json
+++ b/styles/banjo.json
@@ -109,84 +109,16 @@
 			"defaultFontSizes": false,
 			"fluid": true,
 			"fontFamilies": [
-				{
-					"fontFace": [
-						{
-							"fontFamily": "Urbanist",
-							"fontStyle": "normal",
-							"fontWeight": "100 900",
-							"src": [
-								"file:./assets/fonts/urbanist/Urbanist-VariableFont_wght.ttf"
-							]
-						},
-						{
-							"fontFamily": "Urbanist",
-							"fontStyle": "italic",
-							"fontWeight": "100 900",
-							"src": [
-								"file:./assets/fonts/urbanist/Urbanist-Italic-VariableFont_wght.ttf"
-							]
-						}
-					],
-					"fontFamily": "\"Urbanist\", sans-serif",
-					"name": "Urbanist",
-					"slug": "urbanist"
-				},
-				{
-					"fontFace": [
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "normal",
-							"fontWeight": "400",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-Regular.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "italic",
-							"fontWeight": "400",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-Italic.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "normal",
-							"fontWeight": "500",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-Medium.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "italic",
-							"fontWeight": "500",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-MediumItalic.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "normal",
-							"fontWeight": "600",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-SemiBold.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "italic",
-							"fontWeight": "600",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-SemiBoldItalic.ttf"
-							]
-						}
-					],
-					"fontFamily": "Asap Condensed",
-					"name": "Asap Condensed",
-					"slug": "asap-condensed"
-				}
+                                {
+                                        "fontFamily": "sans-serif",
+                                        "name": "Sans Serif",
+                                        "slug": "urbanist"
+                                },
+                                {
+                                        "fontFamily": "\"Varela Round\", sans-serif",
+                                        "name": "Varela Round",
+                                        "slug": "asap-condensed"
+                                }
 			],
 			"fontSizes": [
 				{

--- a/styles/biscuit.json
+++ b/styles/biscuit.json
@@ -109,84 +109,16 @@
 			"defaultFontSizes": false,
 			"fluid": true,
 			"fontFamilies": [
-				{
-					"fontFace": [
-						{
-							"fontFamily": "Urbanist",
-							"fontStyle": "normal",
-							"fontWeight": "100 900",
-							"src": [
-								"file:./assets/fonts/urbanist/Urbanist-VariableFont_wght.ttf"
-							]
-						},
-						{
-							"fontFamily": "Urbanist",
-							"fontStyle": "italic",
-							"fontWeight": "100 900",
-							"src": [
-								"file:./assets/fonts/urbanist/Urbanist-Italic-VariableFont_wght.ttf"
-							]
-						}
-					],
-					"fontFamily": "\"Urbanist\", sans-serif",
-					"name": "Urbanist",
-					"slug": "urbanist"
-				},
-				{
-					"fontFace": [
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "normal",
-							"fontWeight": "400",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-Regular.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "italic",
-							"fontWeight": "400",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-Italic.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "normal",
-							"fontWeight": "500",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-Medium.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "italic",
-							"fontWeight": "500",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-MediumItalic.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "normal",
-							"fontWeight": "600",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-SemiBold.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "italic",
-							"fontWeight": "600",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-SemiBoldItalic.ttf"
-							]
-						}
-					],
-					"fontFamily": "Asap Condensed",
-					"name": "Asap Condensed",
-					"slug": "asap-condensed"
-				}
+                                {
+                                        "fontFamily": "sans-serif",
+                                        "name": "Sans Serif",
+                                        "slug": "urbanist"
+                                },
+                                {
+                                        "fontFamily": "\"Varela Round\", sans-serif",
+                                        "name": "Varela Round",
+                                        "slug": "asap-condensed"
+                                }
 			],
 			"fontSizes": [
 				{

--- a/styles/fang.json
+++ b/styles/fang.json
@@ -109,84 +109,16 @@
 			"defaultFontSizes": false,
 			"fluid": true,
 			"fontFamilies": [
-				{
-					"fontFace": [
-						{
-							"fontFamily": "Urbanist",
-							"fontStyle": "normal",
-							"fontWeight": "100 900",
-							"src": [
-								"file:./assets/fonts/urbanist/Urbanist-VariableFont_wght.ttf"
-							]
-						},
-						{
-							"fontFamily": "Urbanist",
-							"fontStyle": "italic",
-							"fontWeight": "100 900",
-							"src": [
-								"file:./assets/fonts/urbanist/Urbanist-Italic-VariableFont_wght.ttf"
-							]
-						}
-					],
-					"fontFamily": "\"Urbanist\", sans-serif",
-					"name": "Urbanist",
-					"slug": "urbanist"
-				},
-				{
-					"fontFace": [
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "normal",
-							"fontWeight": "400",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-Regular.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "italic",
-							"fontWeight": "400",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-Italic.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "normal",
-							"fontWeight": "500",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-Medium.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "italic",
-							"fontWeight": "500",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-MediumItalic.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "normal",
-							"fontWeight": "600",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-SemiBold.ttf"
-							]
-						},
-						{
-							"fontFamily": "Asap Condensed",
-							"fontStyle": "italic",
-							"fontWeight": "600",
-							"src": [
-								"file:./assets/fonts/asap/AsapCondensed-SemiBoldItalic.ttf"
-							]
-						}
-					],
-					"fontFamily": "Asap Condensed",
-					"name": "Asap Condensed",
-					"slug": "asap-condensed"
-				}
+                                {
+                                        "fontFamily": "sans-serif",
+                                        "name": "Sans Serif",
+                                        "slug": "urbanist"
+                                },
+                                {
+                                        "fontFamily": "\"Varela Round\", sans-serif",
+                                        "name": "Varela Round",
+                                        "slug": "asap-condensed"
+                                }
 			],
 			"fontSizes": [
 				{


### PR DESCRIPTION
## Summary
- load Google Varela Round font
- apply sans-serif font to body and Varela Round to headings
- update theme style variations to use these fonts

## Testing
- `composer validate --no-check-all` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fce90b9048326b506070f447d836f