### PR TITLE
Adjust mission layout and financing spacing

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -78,7 +78,7 @@ get_header();
 
     <div class="container py-4">
 
-    <section class="financing py-5">
+    <section class="financing py-5 mb-5">
         <div class="row align-items-center">
             <div class="col-md-6 text-center text-md-start mb-4 mb-md-0">
                 <img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/finance-pet.png" alt="Finance Pet" class="img-fluid d-block mb-3" />

--- a/patterns/about.php
+++ b/patterns/about.php
@@ -13,14 +13,14 @@
 <div style="height:calc( 0.25 * var(--wp--style--root--padding-right, var(--wp--custom--gap--horizontal)))" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:columns {"align":"wide"} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center"} -->
+<!-- wp:columns {"align":"full"} -->
+<div class="wp-block-columns alignfull"><!-- wp:column {"verticalAlignment":"center"} -->
 <div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading -->
-<h2 class="wp-block-heading"><?php echo esc_html__( 'Meet the pack', 'bark' ); ?></h2>
+<h2 class="wp-block-heading"><i class="fas fa-paw me-2"></i><?php echo esc_html__( 'Meet the pack', 'bark' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Our mission is simple: to bring joy to families by providing them with loyal, loving companions while ensuring the highest standards of health, care, and ethics. We believe every puppy deserves a home where they are cherished.</p>
+<p>Our mission is to bring joy to families with loyal, loving companions. Each puppy is raised with unmatched care and attention, receiving early socialization and comprehensive health checks. We work closely with you to ensure the perfect match so your new friend thrives from day one.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons -->


### PR DESCRIPTION
## Summary
- tweak financing section spacing
- make mission section full width with more text
- add paw icon in "Meet the pack" heading

## Testing
- `php -l front-page.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841d7d6d5288326af72b87cd14192f2