### PR TITLE
Fix mobile menu icon

### DIFF
--- a/header.php
+++ b/header.php
@@ -8,7 +8,7 @@
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
 
-<header class="site-header navbar navbar-expand-lg" style="background-color: #102624;">
+<header class="site-header navbar navbar-dark navbar-expand-lg" style="background-color: #102624;">
     <div class="container-fluid d-flex align-items-center justify-content-between py-2 px-3">
         <div class="d-flex align-items-center">
             <a class="navbar-brand me-4" href="<?php echo esc_url( home_url( '/' ) ); ?>">


### PR DESCRIPTION
## Summary
- ensure bootstrap dark navbar toggler icon is visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842779a6d888326bc30a21337cd142a