### PR TITLE
Restore contact options on pet cards

### DIFF
--- a/template-parts/loop-pet.php
+++ b/template-parts/loop-pet.php
@@ -99,11 +99,10 @@ if ( ! empty( $gform_pet_inquiry_popup ) ) {
                     <small>Call</small>
                 </a>
 
-                <!-- TODO: Uncomment when pet inquiry modal is ready -->
-                <!--a href="#petInquiry" class="btn btn-outline-primary btn-sm d-flex flex-column align-items-center gap-1 z-2 action-icon" data-bs-toggle="modal" data-ref-id="<?= $ref_id ?>" title="Ask a Question">
+                <a href="mailto:01pupworld@gmail.com" class="btn btn-outline-primary btn-sm d-flex flex-column align-items-center gap-1 z-2 action-icon" title="Email Us">
                     <i class="fas fa-envelope"></i>
-                    <small>Ask</small>
-                </a-->
+                    <small>Email</small>
+                </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- include an Email button on each pet card so users can contact easily

## Testing
- `php -l template-parts/loop-pet.php` *(fails: php missing)*

------
https://chatgpt.com/codex/tasks/task_e_684344f8386483268c8981eb5a15f1c2