### PR TITLE
Fix duplicate product listings on category pages

### DIFF
--- a/taxonomy-product_cat.php
+++ b/taxonomy-product_cat.php
@@ -3,7 +3,7 @@ get_header();
 
 get_template_part( 'template-parts/section-start', 'woo', [ 'section_class' => 'container py-5' ] );
 // Display the WooCommerce page header and notices.
-get_template_part( 'template-parts/content', 'woocommerce' );
+// get_template_part( 'template-parts/content', 'woocommerce' );
 
 if ( have_posts() ) {
 	get_template_part( 'template-parts/section-start', 'woo', [ 'section_class' => 'row g-0 row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 list-unstyled mb-5' ] );


### PR DESCRIPTION
## Summary
- stop loading the default WooCommerce loop in `taxonomy-product_cat.php`

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434c7009c88326b5ee66ce81fed3fd