### PR TITLE
Add product detail display template

### DIFF
--- a/template-parts/content-pet.php
+++ b/template-parts/content-pet.php
@@ -10,6 +10,6 @@ get_template_part( 'template-parts/section-start', 'woo', [
     'section_class' => 'container py-5',
 ] );
 
-woocommerce_content();
+get_template_part( 'template-parts/product-details' );
 
 get_template_part( 'template-parts/section-end', 'woo' );

--- a/template-parts/content-product.php
+++ b/template-parts/content-product.php
@@ -10,6 +10,6 @@ get_template_part( 'template-parts/section-start', 'woo', [
     'section_class' => 'container py-5',
 ] );
 
-woocommerce_content();
+get_template_part( 'template-parts/product-details' );
 
 get_template_part( 'template-parts/section-end', 'woo' );

--- a/template-parts/product-details.php
+++ b/template-parts/product-details.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Custom single product layout.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+global $product;
+
+do_action( 'woocommerce_before_single_product' );
+
+if ( post_password_required() ) {
+    echo get_the_password_form();
+    return;
+}
+?>
+<div id="product-<?php the_ID(); ?>" <?php wc_product_class( 'row g-5', $product ); ?>>
+    <div class="col-md-6">
+        <?php do_action( 'woocommerce_before_single_product_summary' ); ?>
+    </div>
+    <div class="col-md-6">
+        <div class="summary entry-summary">
+            <?php do_action( 'woocommerce_single_product_summary' ); ?>
+        </div>
+    </div>
+</div>
+<?php
+    do_action( 'woocommerce_after_single_product_summary' );
+    do_action( 'woocommerce_after_single_product' );
+?>


### PR DESCRIPTION
## Summary
- add a custom template for single product details
- use the new layout for products and pets

## Testing
- `npm test --silent` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435263ffac8326a942d8911b203660