### PR TITLE
Add WooCommerce headers

### DIFF
--- a/taxonomy-product_cat.php
+++ b/taxonomy-product_cat.php
@@ -2,8 +2,12 @@
 get_header();
 
 get_template_part( 'template-parts/section-start', 'woo', [ 'section_class' => 'container py-5' ] );
-// Display the WooCommerce page header and notices.
-// get_template_part( 'template-parts/content', 'woocommerce' );
+
+// WooCommerce page header with breadcrumb, title and description.
+get_template_part( 'template-parts/woocommerce', 'header' );
+
+// Filters and result count before the products grid.
+do_action( 'woocommerce_before_shop_loop' );
 
 if ( have_posts() ) {
 	get_template_part( 'template-parts/section-start', 'woo', [ 'section_class' => 'row g-0 row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 list-unstyled mb-5' ] );
@@ -30,7 +34,12 @@ if ( have_posts() ) {
         get_template_part( 'template-parts/section-end', 'woo' );
 	}
 
-	get_template_part( 'template-parts/section-end', 'woo' );
+        get_template_part( 'template-parts/section-end', 'woo' );
+
+        // Pagination and additional actions.
+        do_action( 'woocommerce_after_shop_loop' );
+} else {
+        do_action( 'woocommerce_no_products_found' );
 }
 
 get_template_part( 'template-parts/section-end', 'woo' );

--- a/template-parts/content-pet.php
+++ b/template-parts/content-pet.php
@@ -10,6 +10,9 @@ get_template_part( 'template-parts/section-start', 'woo', [
     'section_class' => 'container py-5',
 ] );
 
+// WooCommerce page header with breadcrumb and title.
+get_template_part( 'template-parts/woocommerce', 'header' );
+
 get_template_part( 'template-parts/product-details' );
 
 get_template_part( 'template-parts/section-end', 'woo' );

--- a/template-parts/content-product.php
+++ b/template-parts/content-product.php
@@ -10,6 +10,9 @@ get_template_part( 'template-parts/section-start', 'woo', [
     'section_class' => 'container py-5',
 ] );
 
+// WooCommerce page header with breadcrumb and title.
+get_template_part( 'template-parts/woocommerce', 'header' );
+
 get_template_part( 'template-parts/product-details' );
 
 get_template_part( 'template-parts/section-end', 'woo' );

--- a/template-parts/content-woocommerce.php
+++ b/template-parts/content-woocommerce.php
@@ -10,6 +10,9 @@ get_template_part( 'template-parts/section-start', 'woo', [
     'section_class' => 'container py-5',
 ] );
 
+// WooCommerce page header with breadcrumb and title.
+get_template_part( 'template-parts/woocommerce', 'header' );
+
 woocommerce_content();
 
 get_template_part( 'template-parts/section-end', 'woo' );

--- a/template-parts/woocommerce-header.php
+++ b/template-parts/woocommerce-header.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * WooCommerce page header with breadcrumbs, title and description.
+ */
+defined( 'ABSPATH' ) || exit;
+?>
+<header class="page-header mb-4">
+    <?php woocommerce_breadcrumb(); ?>
+    <?php if ( is_shop() || is_product_taxonomy() ) : ?>
+        <h1 class="page-title"><?php echo woocommerce_page_title( false ); ?></h1>
+        <?php do_action( 'woocommerce_archive_description' ); ?>
+    <?php else : ?>
+        <?php the_title( '<h1 class="page-title">', '</h1>' ); ?>
+    <?php endif; ?>
+</header>


### PR DESCRIPTION
## Summary
- show WooCommerce breadcrumbs, titles and archive descriptions
- integrate default shop loop actions for filters/pagination
- include header on WooCommerce content and product templates

## Testing
- `php -l taxonomy-product_cat.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843592cd5e48326a64c9240ca4e1697