### PR TITLE
Improve WooCommerce product layout

### DIFF
--- a/assets/js/product.js
+++ b/assets/js/product.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', function(){
+    if (typeof Swiper !== 'undefined') {
+        new Swiper('.product-gallery-swiper', {
+            loop: true,
+            slidesPerView: 1,
+            spaceBetween: 10,
+            pagination: {
+                el: '.swiper-pagination',
+                clickable: true
+            },
+            navigation: {
+                nextEl: '.swiper-button-next',
+                prevEl: '.swiper-button-prev'
+            }
+        });
+    }
+});

--- a/functions.php
+++ b/functions.php
@@ -34,3 +34,64 @@ $PUPWORLD_THEME = new PUPWORLD_THEME();
 require_once ( dirname( __FILE__ ) . '/load.php' );
 
 require_once ( dirname( __FILE__ ) . '/reviews.php' );
+
+function pupworld_output_product_gallery() {
+    global $product;
+    $main_id = $product->get_image_id();
+    $gallery_ids = $product->get_gallery_image_ids();
+
+    echo '<div class="swiper product-gallery-swiper">';
+    echo '<div class="swiper-wrapper">';
+
+    if ( $main_id ) {
+        $html = wp_get_attachment_image( $main_id, 'large', false, array( 'class' => 'img-fluid' ) );
+        echo '<div class="swiper-slide">' . $html . '</div>';
+    }
+
+    if ( $gallery_ids ) {
+        foreach ( $gallery_ids as $gid ) {
+            $html = wp_get_attachment_image( $gid, 'large', false, array( 'class' => 'img-fluid' ) );
+            echo '<div class="swiper-slide">' . $html . '</div>';
+        }
+    }
+
+    echo '</div>';
+    echo '<div class="swiper-button-next"></div><div class="swiper-button-prev"></div><div class="swiper-pagination"></div>';
+    echo '</div>';
+}
+
+add_action( 'init', function() {
+    remove_action( 'woocommerce_before_single_product_summary', 'woocommerce_show_product_images', 20 );
+    add_action( 'woocommerce_before_single_product_summary', 'pupworld_output_product_gallery', 20 );
+} );
+
+function pupworld_custom_product_badge() {
+    $badge = get_post_meta( get_the_ID(), 'product_badge', true );
+    if ( $badge ) {
+        echo '<span class="product-badge badge bg-success position-absolute top-0 start-0 m-2">' . esc_html( $badge ) . '</span>';
+    }
+}
+add_action( 'woocommerce_before_single_product_summary', 'pupworld_custom_product_badge', 5 );
+
+function pupworld_product_highlights() {
+    if ( function_exists( 'get_field' ) ) {
+        $highlights = get_field( 'product_highlights' );
+        if ( $highlights ) {
+            echo '<ul class="product-highlights list-unstyled mt-3">';
+            foreach ( $highlights as $text ) {
+                echo '<li class="d-flex align-items-start mb-2"><i class="fa-solid fa-check me-2 text-success"></i><span>' . esc_html( $text ) . '</span></li>';
+            }
+            echo '</ul>';
+        }
+    }
+}
+add_action( 'woocommerce_single_product_summary', 'pupworld_product_highlights', 25 );
+
+function pupworld_trust_badges() {
+    echo '<div class="trust-badges mt-3">'
+        . '<span class="me-3"><i class="fa-solid fa-lock"></i> SSL Secure</span>'
+        . '<span class="me-3"><i class="fa-regular fa-credit-card"></i> Safe Payments</span>'
+        . '<span><i class="fa-solid fa-thumbs-up"></i> Satisfaction Guarantee</span>'
+        . '</div>';
+}
+add_action( 'woocommerce_single_product_summary', 'pupworld_trust_badges', 35 );

--- a/load.php
+++ b/load.php
@@ -102,36 +102,62 @@ if ( ! function_exists( 'pupworld_styles' ) ) :
                        null
                );
 
-                wp_register_style(
-                        'pupworld-style',
-                        get_template_directory_uri() . '/style.css',
-                        array( 'bootstrap-css' ),
-                        PUPWORLD_VERSION
-                );
+               wp_register_style(
+                       'pupworld-style',
+                       get_template_directory_uri() . '/style.css',
+                       array( 'bootstrap-css' ),
+                       PUPWORLD_VERSION
+               );
+
+               wp_register_style(
+                       'swiper-css',
+                       'https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css',
+                       array(),
+                       '9.4.1'
+               );
 
                wp_enqueue_style( 'bootstrap-css' );
                wp_enqueue_style( 'font-awesome' );
                wp_enqueue_style( 'pupworld-google-fonts' );
+               wp_enqueue_style( 'swiper-css' );
                wp_enqueue_style( 'pupworld-style' );
 
-                wp_register_script(
-                        'bootstrap-js',
-                        'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js',
-                        array(),
-                        '5.3.2',
-                        true
-                );
+               wp_register_script(
+                       'bootstrap-js',
+                       'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js',
+                       array(),
+                       '5.3.2',
+                       true
+               );
 
-                wp_register_script(
-                        'pupworld-dropdown',
-                        get_template_directory_uri() . '/assets/js/dropdown.js',
-                        array( 'bootstrap-js' ),
-                        PUPWORLD_VERSION,
-                        true
-                );
+               wp_register_script(
+                       'swiper-js',
+                       'https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js',
+                       array(),
+                       '9.4.1',
+                       true
+               );
 
-                wp_enqueue_script( 'bootstrap-js' );
-                wp_enqueue_script( 'pupworld-dropdown' );
+               wp_register_script(
+                       'pupworld-dropdown',
+                       get_template_directory_uri() . '/assets/js/dropdown.js',
+                       array( 'bootstrap-js' ),
+                       PUPWORLD_VERSION,
+                       true
+               );
+
+               wp_register_script(
+                       'pupworld-product',
+                       get_template_directory_uri() . '/assets/js/product.js',
+                       array( 'swiper-js' ),
+                       PUPWORLD_VERSION,
+                       true
+               );
+
+               wp_enqueue_script( 'bootstrap-js' );
+               wp_enqueue_script( 'pupworld-dropdown' );
+               wp_enqueue_script( 'swiper-js' );
+               wp_enqueue_script( 'pupworld-product' );
 
         }
 

--- a/style.css
+++ b/style.css
@@ -389,3 +389,61 @@ section {
     background-color: #b4e88a;
     color: #102624;
 }
+
+/* Product gallery swiper */
+.product-gallery-swiper {
+    position: relative;
+    width: 100%;
+    border-radius: 0.5rem;
+    overflow: hidden;
+}
+.product-gallery-swiper img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+/* Product tabs styling */
+.woocommerce-tabs .wc-tabs {
+    border-bottom: none;
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+.woocommerce-tabs .wc-tabs li {
+    list-style: none;
+}
+.woocommerce-tabs .wc-tabs li a {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    border-radius: 50rem;
+    background: #f5f5f5;
+    color: #102624;
+    text-decoration: none;
+}
+.woocommerce-tabs .wc-tabs li.active a,
+.woocommerce-tabs .wc-tabs li a:hover {
+    background: #cbfba0;
+}
+.woocommerce-tabs .panel {
+    animation: fadeIn 0.3s ease-in-out;
+}
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* Sticky add to cart on mobile */
+@media (max-width: 767.98px) {
+    .single-product-details form.cart {
+        position: sticky;
+        bottom: 0;
+        background: #fff;
+        padding: 1rem;
+        z-index: 1000;
+    }
+}
+
+.product-badge {
+    font-size: 0.875rem;
+}

--- a/template-parts/product-details.php
+++ b/template-parts/product-details.php
@@ -16,10 +16,10 @@ if ( post_password_required() ) {
 }
 ?>
 <div id="product-<?php the_ID(); ?>" <?php wc_product_class( 'row g-5 align-items-start single-product-details', $product ); ?>>
-    <div class="col-md-6">
+    <div class="col-lg-7">
         <?php do_action( 'woocommerce_before_single_product_summary' ); ?>
     </div>
-    <div class="col-md-6">
+    <div class="col-lg-5">
         <div class="summary entry-summary bg-white p-4 rounded-3 shadow-sm">
             <?php do_action( 'woocommerce_single_product_summary' ); ?>
         </div>


### PR DESCRIPTION
## Summary
- modernize WooCommerce single product layout
- add Swiper based product gallery and sticky add to cart on mobile
- provide product highlights, trust badges and optional badge
- enqueue Swiper assets and product script

## Testing
- `npm -v`
- `php -l functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435cc3d6c88326ad5dc835c89ef16d