### PR TITLE
Improve WooCommerce single product layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -447,3 +447,28 @@ section {
 .product-badge {
     font-size: 0.875rem;
 }
+
+/* Product highlight list */
+.product-highlights {
+    font-size: 0.9rem;
+}
+.product-highlights i {
+    color: #28a745;
+    margin-right: 0.25rem;
+}
+
+/* Trust badges */
+.trust-badges {
+    font-size: 0.875rem;
+    color: #102624;
+}
+.trust-badges i {
+    color: #cbfba0;
+    margin-right: 0.25rem;
+}
+
+@media (max-width: 767.98px) {
+    .single-product-details .single_add_to_cart_button {
+        width: 100%;
+    }
+}

--- a/template-parts/product-details.php
+++ b/template-parts/product-details.php
@@ -15,17 +15,19 @@ if ( post_password_required() ) {
     return;
 }
 ?>
-<div id="product-<?php the_ID(); ?>" <?php wc_product_class( 'row g-5 align-items-start single-product-details', $product ); ?>>
+<section id="product-<?php the_ID(); ?>" <?php wc_product_class( 'single-product-details row g-5 align-items-start', $product ); ?>>
     <div class="col-lg-7">
-        <?php do_action( 'woocommerce_before_single_product_summary' ); ?>
-    </div>
-    <div class="col-lg-5">
-        <div class="summary entry-summary bg-white p-4 rounded-3 shadow-sm">
-            <?php do_action( 'woocommerce_single_product_summary' ); ?>
+        <div class="product-media">
+            <?php do_action( 'woocommerce_before_single_product_summary' ); ?>
         </div>
     </div>
-</div>
-<?php
-    do_action( 'woocommerce_after_single_product_summary' );
-    do_action( 'woocommerce_after_single_product' );
-?>
+    <div class="col-lg-5">
+        <article class="summary entry-summary bg-white p-4 rounded-3 shadow-sm">
+            <?php do_action( 'woocommerce_single_product_summary' ); ?>
+        </article>
+    </div>
+    <div class="col-12">
+        <?php do_action( 'woocommerce_after_single_product_summary' ); ?>
+    </div>
+</section>
+<?php do_action( 'woocommerce_after_single_product' ); ?>


### PR DESCRIPTION
## Summary
- convert product markup to a semantic section and article layout
- add styling for highlight list, trust badges and mobile cart button

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435f03e67c8326bf6a357c782c6196