### PR TITLE
Fix WooCommerce single product template loading

### DIFF
--- a/template-parts/content-pet.php
+++ b/template-parts/content-pet.php
@@ -13,6 +13,12 @@ get_template_part( 'template-parts/section-start', 'woo', [
 // WooCommerce page header with breadcrumb and title.
 get_template_part( 'template-parts/woocommerce', 'header' );
 
-get_template_part( 'template-parts/product-details' );
+// Load the detailed single product layout if available.
+if ( function_exists( 'wc_get_template_part' ) ) {
+    // Allows WooCommerce templates under /woocommerce to override the layout.
+    wc_get_template_part( 'content', 'single-product' );
+} else {
+    get_template_part( 'template-parts/product-details' );
+}
 
 get_template_part( 'template-parts/section-end', 'woo' );

--- a/template-parts/content-product.php
+++ b/template-parts/content-product.php
@@ -13,6 +13,13 @@ get_template_part( 'template-parts/section-start', 'woo', [
 // WooCommerce page header with breadcrumb and title.
 get_template_part( 'template-parts/woocommerce', 'header' );
 
-get_template_part( 'template-parts/product-details' );
+// Load the detailed single product layout if available.
+if ( function_exists( 'wc_get_template_part' ) ) {
+    // This allows WooCommerce templates under the theme's /woocommerce folder
+    // to override the single product layout (e.g. content-single-product.php).
+    wc_get_template_part( 'content', 'single-product' );
+} else {
+    get_template_part( 'template-parts/product-details' );
+}
 
 get_template_part( 'template-parts/section-end', 'woo' );


### PR DESCRIPTION
## Summary
- load WooCommerce's `content-single-product` template instead of the simple old `product-details` template
- fall back to old template if WooCommerce not loaded

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684457cbbdbc83269874ca1430ee1b6d