### PR TITLE
Remove page header from product details

### DIFF
--- a/template-parts/content-pet.php
+++ b/template-parts/content-pet.php
@@ -10,8 +10,6 @@ get_template_part( 'template-parts/section-start', 'woo', [
     'section_class' => 'container py-5',
 ] );
 
-// WooCommerce page header with breadcrumb and title.
-get_template_part( 'template-parts/woocommerce', 'header' );
 
 // Load the detailed single product layout if available.
 if ( function_exists( 'wc_get_template_part' ) ) {

--- a/template-parts/content-product.php
+++ b/template-parts/content-product.php
@@ -10,8 +10,6 @@ get_template_part( 'template-parts/section-start', 'woo', [
     'section_class' => 'container py-5',
 ] );
 
-// WooCommerce page header with breadcrumb and title.
-get_template_part( 'template-parts/woocommerce', 'header' );
 
 // Load the detailed single product layout if available.
 if ( function_exists( 'wc_get_template_part' ) ) {


### PR DESCRIPTION
## Summary
- remove WooCommerce header section from single-product templates

## Testing
- `php -l template-parts/content-product.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6844590fdf5c83269ea3dd61419c62ed