### PR TITLE
Add WooCommerce account and cart icons

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -95,3 +95,31 @@ function pupworld_trust_badges() {
         . '</div>';
 }
 add_action( 'woocommerce_single_product_summary', 'pupworld_trust_badges', 35 );
+
+/**
+ * Output cart icon markup used in the header.
+ */
+function pupworld_cart_link() {
+    if ( ! function_exists( 'WC' ) ) {
+        return;
+    }
+    $count = WC()->cart->get_cart_contents_count();
+    echo '<a href="' . esc_url( wc_get_cart_url() ) . '" class="cart-icon text-light position-relative">'
+        . '<i class="fa-solid fa-shopping-cart"></i>';
+    if ( $count > 0 ) {
+        echo '<span class="cart-count position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">'
+            . esc_html( $count ) . '</span>';
+    }
+    echo '</a>';
+}
+
+/**
+ * Ensure cart icon fragments are updated via AJAX when products are added.
+ */
+function pupworld_cart_link_fragment( $fragments ) {
+    ob_start();
+    pupworld_cart_link();
+    $fragments['a.cart-icon'] = ob_get_clean();
+    return $fragments;
+}
+add_filter( 'woocommerce_add_to_cart_fragments', 'pupworld_cart_link_fragment' );

--- a/header.php
+++ b/header.php
@@ -20,6 +20,11 @@
             </div>
         </div>
 
+        <div class="mobile-icons d-lg-none d-flex align-items-center me-2">
+            <a href="<?php echo esc_url( wc_get_page_permalink( 'myaccount' ) ); ?>" class="text-light me-3 account-icon"><i class="fa-solid fa-user"></i></a>
+            <?php pupworld_cart_link(); ?>
+        </div>
+
         <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#primaryOffcanvas" aria-controls="primaryOffcanvas" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
@@ -36,11 +41,15 @@
             ) );
             ?>
             <div class="header-right d-flex align-items-center">
+                <span class="text-light px-3">|</span>
                 <div class="social-icons me-3">
                     <a href="#" class="text-light me-2"><i class="fab fa-facebook-f"></i></a>
                     <a href="#" class="text-light me-2"><i class="fab fa-twitter"></i></a>
                     <a href="#" class="text-light"><i class="fab fa-instagram"></i></a>
                 </div>
+                <span class="text-light px-3">|</span>
+                <a href="<?php echo esc_url( wc_get_page_permalink( 'myaccount' ) ); ?>" class="text-light me-3 account-icon"><i class="fa-solid fa-user"></i></a>
+                <?php pupworld_cart_link(); ?>
             </div>
         </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -76,6 +76,19 @@ h1, h2, h3, h4, h5, h6 {
     color: #f2a307;
 }
 
+/* Account and cart icons */
+.account-icon,
+.cart-icon {
+    color: #f7f7f3;
+}
+.account-icon:hover,
+.cart-icon:hover {
+    color: #f2a307;
+}
+.cart-count {
+    font-size: 0.75rem;
+}
+
 .header-phone i {
     margin-right: 4px;
 }


### PR DESCRIPTION
## Summary
- add mobile account and cart icons next to hamburger menu
- show account/cart icons after social links on desktop
- include vertical separators on desktop
- implement AJAX-updated cart count
- style new account and cart icons

## Testing
- `php` *not available*


------
https://chatgpt.com/codex/tasks/task_e_684473d8b74c83268a9d51f3b33664f8