### PR TITLE
Update header icons to inline SVG

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -105,7 +105,9 @@ function pupworld_cart_link() {
     }
     $count = WC()->cart->get_cart_contents_count();
     echo '<a href="' . esc_url( wc_get_cart_url() ) . '" class="cart-icon text-light position-relative">'
-        . '<img src="' . get_template_directory_uri() . '/assets/images/cart.svg" width="20" height="20" alt="Cart" />';
+        . '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">'
+        . '<path d="M0 1.5A.5.5 0 0 1 .5 1H2a.5.5 0 0 1 .485.379L2.89 3H14.5a.5.5 0 0 1 .49.598l-1.5 7A.5.5 0 0 1 13 11H4a.5.5 0 0 1-.491-.408L1.01 3.607A.5.5 0 0 1 1 3.5V2H.5a.5.5 0 0 1-.5-.5zM5 12a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm7 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4z"/>'
+        . '</svg>';
     if ( $count > 0 ) {
         echo '<span class="cart-count position-absolute top-0 start-100 translate-middle badge rounded-pill">'
             . esc_html( $count ) . '</span>';

--- a/header.php
+++ b/header.php
@@ -22,7 +22,10 @@
 
         <div class="mobile-icons d-lg-none d-flex align-items-center me-2">
             <a href="<?php echo esc_url( wc_get_page_permalink( 'myaccount' ) ); ?>" class="text-light me-3 account-icon">
-                <img src="<?php echo get_template_directory_uri(); ?>/assets/images/user.svg" width="20" height="20" alt="Account" />
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+                    <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/>
+                    <path d="M2 14s-1 0-1-1 1-4 7-4 7 3 7 4-1 1-1 1H2z"/>
+                </svg>
             </a>
             <?php pupworld_cart_link(); ?>
         </div>
@@ -51,7 +54,10 @@
                 </div>
                 <span class="text-light px-3">|</span>
                 <a href="<?php echo esc_url( wc_get_page_permalink( 'myaccount' ) ); ?>" class="text-light me-3 account-icon">
-                    <img src="<?php echo get_template_directory_uri(); ?>/assets/images/user.svg" width="20" height="20" alt="Account" />
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+                        <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/>
+                        <path d="M2 14s-1 0-1-1 1-4 7-4 7 3 7 4-1 1-1 1H2z"/>
+                    </svg>
                 </a>
                 <?php pupworld_cart_link(); ?>
             </div>

--- a/style.css
+++ b/style.css
@@ -82,8 +82,10 @@ h1, h2, h3, h4, h5, h6 {
     color: #f7f7f3;
 }
 .account-icon:hover,
-.cart-icon:hover {
-    color: #f2a307;
+.account-icon:active,
+.cart-icon:hover,
+.cart-icon:active {
+    color: #cccccc;
 }
 .cart-count {
     font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- inline the account SVG and cart SVG markup
- keep icons white by default
- make icons gray on hover or active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68447765bf5883268828d148a0e638ce