### PR TITLE
Improve shop filter layout and dropdown style

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -125,3 +125,20 @@ function pupworld_cart_link_fragment( $fragments ) {
     return $fragments;
 }
 add_filter( 'woocommerce_add_to_cart_fragments', 'pupworld_cart_link_fragment' );
+
+/**
+ * Display result count above catalog ordering dropdown.
+ */
+function pupworld_shop_controls() {
+    echo '<div class="pupworld-shop-controls">';
+    woocommerce_result_count();
+    woocommerce_catalog_ordering();
+    echo '</div>';
+}
+
+add_action( 'init', function() {
+    remove_action( 'woocommerce_before_shop_loop', 'woocommerce_result_count', 20 );
+    remove_action( 'woocommerce_before_shop_loop', 'woocommerce_catalog_ordering', 30 );
+    add_action( 'woocommerce_before_shop_loop', 'pupworld_shop_controls', 20 );
+} );
+

--- a/style.css
+++ b/style.css
@@ -666,3 +666,26 @@ section {
             .product-primary-info .breed-info { font-size: 1.1rem; }
             #nav-breedinfo .row.row-cols-lg-4 > .col { width: 100%; }
         }
+
+/* WooCommerce shop controls */
+.pupworld-shop-controls {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    margin-bottom: 1rem;
+}
+.pupworld-shop-controls .woocommerce-result-count {
+    font-size: 0.875rem;
+    color: #6c757d;
+    margin-bottom: 0.25rem;
+}
+
+/* Global dropdown style */
+select,
+.form-select {
+    background-color: #f8f9fa;
+    border: 1px solid #ced4da;
+    padding: 0.375rem 0.75rem;
+    border-radius: 0.25rem;
+    color: #212529;
+}


### PR DESCRIPTION
## Summary
- show WooCommerce result count stacked above the shop ordering dropdown
- add global styling for dropdown selects

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68447a1c41788326ae8b041199c901d1