### PR TITLE
Add WooCommerce cart/checkout overrides and button styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -749,6 +749,8 @@ select,
     max-width: 960px;
     margin-left: auto;
     margin-right: auto;
+    margin-top: 2rem;
+    margin-bottom: 2rem;
 }
 
 /* Style WooCommerce block buttons to match theme buttons */
@@ -765,6 +767,23 @@ select,
 .wc-block-components-button:hover,
 .wc-block-cart__submit-button:hover,
 .wc-block-components-checkout-place-order-button:hover {
+    background-color: #b4e88a;
+    color: #102624;
+}
+
+/* WooCommerce Deposits plugin button styling */
+.wc-deposits-wrapper .button,
+.wc-deposits-wrapper button.button,
+.wc-deposits-wrapper input.button {
+    background-color: #cbfba0;
+    color: #102624;
+    border: none;
+    border-radius: 50rem;
+    padding: 0.6rem 1.5rem;
+}
+.wc-deposits-wrapper .button:hover,
+.wc-deposits-wrapper button.button:hover,
+.wc-deposits-wrapper input.button:hover {
     background-color: #b4e88a;
     color: #102624;
 }

--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Template overrides WooCommerce cart layout
+ * Wraps default cart.php template in a centered container with margins
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+// Start wrapper div for centering and spacing
+?>
+<div class="woo-cart-wrapper container my-5">
+    <?php
+    // Load original WooCommerce cart template from plugin
+    wc_get_template( 'cart/cart.php', array(), '', WC()->plugin_path() . '/templates/' );
+    ?>
+</div>

--- a/woocommerce/checkout/form-checkout.php
+++ b/woocommerce/checkout/form-checkout.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Template overrides WooCommerce checkout layout
+ * Wraps default form-checkout.php template in a centered container with margins
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+?>
+<div class="woo-checkout-wrapper container my-5">
+    <?php
+    wc_get_template( 'checkout/form-checkout.php', array(), '', WC()->plugin_path() . '/templates/' );
+    ?>
+</div>


### PR DESCRIPTION
## Summary
- center cart and checkout pages with wrapper templates
- style WooCommerce block buttons consistently
- add styling for WooCommerce Deposits buttons

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684483249208832687438fe59df9aa3c