### PR TITLE
Add centered cart/checkout templates and style updates

### DIFF
--- a/cart-page-template.php
+++ b/cart-page-template.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Template Name: Cart Page Template
+ */
+get_header();
+?>
+<main id="primary" class="site-main">
+    <div class="container my-5" style="max-width:960px;">
+        <h1 class="page-title text-center mb-4"><?php the_title(); ?></h1>
+        <?php echo do_shortcode('[woocommerce_cart]'); ?>
+    </div>
+</main>
+<?php
+get_footer();
+?>

--- a/checkout-page-template.php
+++ b/checkout-page-template.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Template Name: Checkout Page Template
+ */
+get_header();
+?>
+<main id="primary" class="site-main">
+    <div class="container my-5" style="max-width:960px;">
+        <h1 class="page-title text-center mb-4"><?php the_title(); ?></h1>
+        <?php echo do_shortcode('[woocommerce_checkout]'); ?>
+    </div>
+</main>
+<?php
+get_footer();
+?>

--- a/style.css
+++ b/style.css
@@ -755,39 +755,50 @@ select,
     margin-bottom: 2rem;
 }
 
-/* Style WooCommerce block buttons to match theme buttons */
+/* Style WooCommerce block buttons to match product detail buttons */
 .wc-block-components-button,
 .wc-block-cart__submit-button,
 .wc-block-components-checkout-place-order-button {
-    background-color: #cbfba0;
-    color: #102624;
-    border: none;
-    border-radius: 50rem;
+    background-color: #f2a307;
+    color: #fff;
+    border: 1px solid #f2a307;
+    border-radius: 0.25rem;
     padding: 0.6rem 1.5rem;
+    transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
 }
-
 .wc-block-components-button:hover,
 .wc-block-cart__submit-button:hover,
 .wc-block-components-checkout-place-order-button:hover {
-    background-color: #b4e88a;
-    color: #102624;
+    background-color: #f2a307;
+    color: #fff;
+    border-color: #c08d06;
 }
 
 /* WooCommerce Deposits plugin button styling */
 .wc-deposits-wrapper .button,
 .wc-deposits-wrapper button.button,
 .wc-deposits-wrapper input.button {
-    background-color: #cbfba0;
-    color: #102624;
-    border: none;
-    border-radius: 50rem;
+    background-color: #f2a307;
+    color: #fff;
+    border: 1px solid #f2a307;
+    border-radius: 0.25rem;
     padding: 0.6rem 1.5rem;
+    transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
 }
 .wc-deposits-wrapper .button:hover,
 .wc-deposits-wrapper button.button:hover,
 .wc-deposits-wrapper input.button:hover {
-    background-color: #b4e88a;
-    color: #102624;
+    background-color: #f2a307;
+    color: #fff;
+    border-color: #c08d06;
+}
+.wc-deposits-wrapper .button:focus,
+.wc-deposits-wrapper button.button:focus,
+.wc-deposits-wrapper input.button:focus {
+    background-color: #f2a307;
+    color: #fff;
+    border-color: #c08d06;
+    box-shadow: 0 0 0 0.25rem rgba(185,142,72,0.5);
 }
 
 /* Center titles on WooCommerce block pages */


### PR DESCRIPTION
## Summary
- create Cart and Checkout page templates with centered container and page title
- restyle WooCommerce block buttons and deposits plugin buttons to match product detail page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844884e00888326aff336cbda2db752