### PR TITLE
Remove shortcodes from cart and checkout templates

### DIFF
--- a/cart-page-template.php
+++ b/cart-page-template.php
@@ -6,8 +6,10 @@ get_header();
 ?>
 <main id="primary" class="site-main">
     <div class="container my-5" style="max-width:960px;">
-        <h1 class="page-title text-center mb-4"><?php the_title(); ?></h1>
-        <?php echo do_shortcode('[woocommerce_cart]'); ?>
+        <?php while ( have_posts() ) : the_post(); ?>
+            <h1 class="page-title text-center mb-4"><?php the_title(); ?></h1>
+            <?php the_content(); ?>
+        <?php endwhile; ?>
     </div>
 </main>
 <?php

--- a/checkout-page-template.php
+++ b/checkout-page-template.php
@@ -6,8 +6,10 @@ get_header();
 ?>
 <main id="primary" class="site-main">
     <div class="container my-5" style="max-width:960px;">
-        <h1 class="page-title text-center mb-4"><?php the_title(); ?></h1>
-        <?php echo do_shortcode('[woocommerce_checkout]'); ?>
+        <?php while ( have_posts() ) : the_post(); ?>
+            <h1 class="page-title text-center mb-4"><?php the_title(); ?></h1>
+            <?php the_content(); ?>
+        <?php endwhile; ?>
     </div>
 </main>
 <?php


### PR DESCRIPTION
## Summary
- update `cart-page-template.php` and `checkout-page-template.php` to display page block content instead of shortcodes

## Testing
- `php -l cart-page-template.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448a34e70c83269427811478d4ca28